### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/tracker-group.js
+++ b/lib/tracker-group.js
@@ -103,7 +103,7 @@ TrackerGroup.prototype.finish = function () {
 var buffer = '                                  '
 TrackerGroup.prototype.debug = function (depth) {
   depth = depth || 0
-  var indent = depth ? buffer.substr(0, depth) : ''
+  var indent = depth ? buffer.slice(0, depth) : ''
   var output = indent + (this.name || 'top') + ': ' + this.completed() + '\n'
   this.trackers.forEach(function (tracker) {
     if (tracker instanceof TrackerGroup) {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.