### PR TITLE
deps: remove readable-stream

### DIFF
--- a/lib/tracker-stream.js
+++ b/lib/tracker-stream.js
@@ -1,5 +1,5 @@
 'use strict'
-const stream = require('readable-stream')
+const stream = require('stream')
 const delegate = require('delegates')
 const Tracker = require('./tracker.js')
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "tap": "^16.0.1"
   },
   "dependencies": {
-    "delegates": "^1.0.0",
-    "readable-stream": "^4.1.0"
+    "delegates": "^1.0.0"
   },
   "files": [
     "bin/",

--- a/test/lib/trackerstream.js
+++ b/test/lib/trackerstream.js
@@ -1,7 +1,7 @@
 'use strict'
 var test = require('tap').test
 var util = require('util')
-var stream = require('readable-stream')
+var stream = require('stream')
 var TrackerStream = require('../..').TrackerStream
 var testEvent = require('./test-event.js')
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This PR removes dependency on `readable-stream` module which is basically just a mirror of the Node.js `stream` module. As such, there's no reason to use it over the built in module. There's 0 effect of this change - all tests are passing without touching anything.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
